### PR TITLE
Prod hardening: Redis FSM storage, compose Redis service, README and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - **Работа с HTTP**: aiohttp (для API Open Food Facts)
 - **Работа с часовыми поясами**: pytz
 - **Контейнеризация**: Docker, Docker Compose
+- **Кэш/хранилище состояний FSM**: Redis 7+
 - **Зависимости**: python-dotenv
 
 ## Установка и запуск
@@ -76,11 +77,7 @@
    - Установить PostgreSQL, если не установлен.
    - Создать базу данных (например, `meal_taken_bot_db`).
    - Создать пользователя и выдать ему права на эту базу.
-   - Установить расширение `pg_trgm`:
-
-     ```sql
-     CREATE EXTENSION IF NOT EXISTS pg_trgm;
-     ```
+   - Расширение `pg_trgm` создается автоматически при старте бота (если у пользователя БД есть права на `CREATE EXTENSION`).
 
 5. **Создать файл `.env`**:
 
@@ -94,6 +91,8 @@
      DB_HOST=localhost # Или адрес вашего сервера БД
      DB_PORT=5432 # Или другой порт
      DB_NAME=имя_бд # Например, meal_taken_bot_db
+     FSM_STORAGE=redis # или memory
+     REDIS_URL=redis://localhost:6379/0
      ```
 
 6. **Запустить бота**:
@@ -116,6 +115,8 @@
    - Заполни `BOT_TOKEN`, `DB_USER`, `DB_PASS`, `DB_NAME`.
    - Установи `DB_HOST=db` (имя сервиса БД из `docker-compose.yml`).
    - Установи `DB_PORT=5432`.
+   - Установи `FSM_STORAGE=redis`.
+   - Установи `REDIS_URL=redis://redis:6379/0`.
 
 3. **Запустить контейнеры**:
 
@@ -125,17 +126,14 @@
 
    > Флаг `--build` нужен при первом запуске и после изменений в коде или `Dockerfile`.
 
-4. **Установить расширение `pg_trgm` (только при первом запуске базы данных)**:
-
-   ```bash
-   docker compose exec db psql -U ${DB_USER} -d ${DB_NAME} -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
-   ```
+4. **Проверить, что у пользователя БД есть права на создание расширений** (нужно для автоинициализации `pg_trgm` при первом старте).
 
 5. **Просмотр логов**:
 
    ```bash
    docker compose logs -f bot # Логи бота
    docker compose logs -f db  # Логи базы данных
+   docker compose logs -f redis # Логи Redis
    ```
 
 6. **Остановка**:

--- a/config.py
+++ b/config.py
@@ -24,11 +24,17 @@ DB_HOST = os.getenv("DB_HOST")
 DB_PORT = os.getenv("DB_PORT", 5432)
 DB_NAME = os.getenv("DB_NAME")
 
+# --- Настройки FSM хранилища ---
+# FSM_STORAGE - тип хранилища FSM: 'memory' или 'redis'
+# REDIS_URL - URL подключения к Redis (например redis://redis:6379/0)
+FSM_STORAGE = os.getenv("FSM_STORAGE", "redis").strip().lower()
+REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
+
 # Проверка наличия всех необходимых переменных окружения
 # Если какой-либо из параметров подключения отсутствует, логируем критическую ошибку и выходим из программы
 if not all([BOT_TOKEN, DB_USER, DB_PASS, DB_HOST, DB_NAME]):
     logger.critical("Не хватает переменных окружения для запуска бота и подключения к БД!")
-    exit("Ошибка: Необходимые переменные окружения не установлены.")
+    raise RuntimeError("Ошибка: Необходимые переменные окружения не установлены.")
 
 # URL-кодируем пароль
 DB_PASS_ENCODED = quote_plus(DB_PASS)
@@ -38,4 +44,3 @@ DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASS_ENCODED}@{DB_HOST}:{DB_PORT}/{D
 
 # Строка подключения для логирования (без пароля)
 DATABASE_URL_LOG = f"postgresql://{DB_USER}:******@{DB_HOST}:{DB_PORT}/{DB_NAME}"
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     depends_on:
       db:
         condition: service_healthy # Ждать, пока сервис db не станет "здоровым" (см. healthcheck ниже)
+      redis:
+        condition: service_healthy # Ждать готовности Redis для FSM
     networks:
       - bot-network # Подключаем к нашей сети
 
@@ -41,6 +43,22 @@ services:
       timeout: 5s # Таймаут проверки 5 секунд
       retries: 5 # 5 попыток перед тем, как считать сервис нездоровым
 
+  # Сервис для Redis (FSM storage)
+  redis:
+    image: redis:7-alpine
+    container_name: calorie_bot_redis_container
+    restart: always
+    command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
+    volumes:
+      - redis_data:/data
+    networks:
+      - bot-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 # Определяем сети
 networks:
   bot-network:
@@ -49,3 +67,4 @@ networks:
 # Определяем именованные тома для сохранения данных
 volumes:
   postgres_data: # Данные будут храниться здесь даже после удаления контейнера
+  redis_data: # Данные Redis (FSM)

--- a/handlers/settings.py
+++ b/handlers/settings.py
@@ -2,7 +2,7 @@ import logging
 import pytz
 from html import escape
 # Используем date из datetime для работы с датой
-from datetime import date, datetime, UTC
+from datetime import date, datetime, timezone
 from aiogram import Router, F, Bot
 from aiogram.filters import Command, StateFilter
 from aiogram.types import Message, ReplyKeyboardRemove, CallbackQuery
@@ -84,7 +84,7 @@ async def recalculate_and_save_goal(user_id: int, state: FSMContext):
     # Сохранение нормы и запись в историю
     try:
         await db.update_user_daily_goal(db.db_pool, user_id, calories)
-        today_utc_date = datetime.now(UTC).date()
+        today_utc_date = datetime.now(timezone.utc).date()
         await db.add_goal_history_entry(
             db.db_pool, user_id, today_utc_date, calories
         )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+addopts = -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv>=1.0.0
 asyncpg>=0.29.0
 aiohttp>=3.9.0
 pytz>=2023.3
+redis>=5.0.0

--- a/tests/check_critical_coverage.py
+++ b/tests/check_critical_coverage.py
@@ -1,0 +1,93 @@
+"""Проверка покрытия критического функционала без внешних зависимостей (stdlib trace)."""
+
+from __future__ import annotations
+
+import inspect
+import os
+import trace
+from pathlib import Path
+
+import pytest
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+# Гарантируем импорт модулей проекта в тестовой среде
+os.environ.setdefault("BOT_TOKEN", "test-token")
+os.environ.setdefault("DB_USER", "test-user")
+os.environ.setdefault("DB_PASS", "test-pass")
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_NAME", "test-db")
+
+import utils
+from handlers import reports
+
+
+CRITICAL_FUNCTIONS = [
+    utils.calculate_lbm,
+    utils.calculate_target_macros_and_calories,
+    reports.calculate_average_for_period,
+    reports.calculate_total_norm_for_period,
+]
+
+
+def _function_source_lines(func):
+    """Возвращает реально исполняемые строки функции по таблице байткода."""
+    executable = set()
+    for _, _, lineno in func.__code__.co_lines():
+        if lineno is None:
+            continue
+        if lineno == func.__code__.co_firstlineno:
+            # строка с `def ...`
+            continue
+        executable.add(lineno)
+    return sorted(executable)
+
+
+def main() -> int:
+    tracer = trace.Trace(count=True, trace=False)
+    exit_code = tracer.runfunc(pytest.main, ["-q"])
+
+    # pytest.main returns int exit code
+    if exit_code != 0:
+        print(f"pytest failed with exit code {exit_code}")
+        return int(exit_code)
+
+    results = tracer.results()
+    counts = results.counts
+
+    total_lines = 0
+    covered_lines = 0
+
+    print("Critical coverage details:")
+
+    for func in CRITICAL_FUNCTIONS:
+        lines = _function_source_lines(func)
+        filename = str(Path(inspect.getsourcefile(func)).resolve())
+        function_total = len(lines)
+        function_covered = 0
+
+        for lineno in lines:
+            total_lines += 1
+            if counts.get((filename, lineno), 0) > 0:
+                covered_lines += 1
+                function_covered += 1
+
+        ratio = (function_covered / function_total * 100) if function_total else 100.0
+        print(f"- {func.__module__}.{func.__name__}: {function_covered}/{function_total} ({ratio:.2f}%)")
+
+    total_ratio = (covered_lines / total_lines * 100) if total_lines else 100.0
+    print(f"TOTAL critical coverage: {covered_lines}/{total_lines} ({total_ratio:.2f}%)")
+
+    if total_ratio < 95.0:
+        print("Critical coverage below 95% threshold")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_main_storage.py
+++ b/tests/test_main_storage.py
@@ -1,0 +1,42 @@
+import os
+
+os.environ.setdefault("BOT_TOKEN", "test-token")
+os.environ.setdefault("DB_USER", "test-user")
+os.environ.setdefault("DB_PASS", "test-pass")
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_NAME", "test-db")
+
+import main
+
+
+class DummyRedisStorage:
+    @staticmethod
+    def from_url(url: str):
+        return {"kind": "redis", "url": url}
+
+
+def test_create_fsm_storage_redis_success(monkeypatch):
+    monkeypatch.setattr(main.config, "FSM_STORAGE", "redis")
+    monkeypatch.setattr(main.config, "REDIS_URL", "redis://redis:6379/0")
+    monkeypatch.setattr(main, "RedisStorage", DummyRedisStorage)
+
+    storage = main.create_fsm_storage()
+
+    assert storage == {"kind": "redis", "url": "redis://redis:6379/0"}
+
+
+def test_create_fsm_storage_redis_fallback_when_import_missing(monkeypatch):
+    monkeypatch.setattr(main.config, "FSM_STORAGE", "redis")
+    monkeypatch.setattr(main, "RedisStorage", None)
+
+    storage = main.create_fsm_storage()
+
+    assert isinstance(storage, main.MemoryStorage)
+
+
+def test_create_fsm_storage_memory(monkeypatch):
+    monkeypatch.setattr(main.config, "FSM_STORAGE", "memory")
+
+    storage = main.create_fsm_storage()
+
+    assert isinstance(storage, main.MemoryStorage)

--- a/tests/test_reports_logic.py
+++ b/tests/test_reports_logic.py
@@ -1,0 +1,84 @@
+import os
+from datetime import date
+
+# Минимальный набор переменных, чтобы импорт модулей проходил в тестовой среде
+os.environ.setdefault("BOT_TOKEN", "test-token")
+os.environ.setdefault("DB_USER", "test-user")
+os.environ.setdefault("DB_PASS", "test-pass")
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_NAME", "test-db")
+
+from handlers.reports import calculate_average_for_period, calculate_total_norm_for_period
+
+
+def test_calculate_average_for_period_regular_case():
+    assert calculate_average_for_period(14000, 7) == 2000
+
+
+def test_calculate_average_for_period_zero_days():
+    assert calculate_average_for_period(14000, 0) == 0
+
+
+def test_calculate_total_norm_no_history_with_current_goal():
+    total, avg, ok = calculate_total_norm_for_period(
+        period_start_date=date(2026, 1, 1),
+        period_days=7,
+        historical_norms_records=[],
+        current_daily_goal=2100,
+    )
+    assert ok is True
+    assert total == 14700
+    assert avg == 2100
+
+
+def test_calculate_total_norm_no_history_no_goal():
+    total, avg, ok = calculate_total_norm_for_period(
+        period_start_date=date(2026, 1, 1),
+        period_days=7,
+        historical_norms_records=[],
+        current_daily_goal=None,
+    )
+    assert (total, avg, ok) == (0, 0, False)
+
+
+def test_calculate_total_norm_from_history_full_period():
+    history = [
+        {"effective_date": date(2026, 1, 1), "daily_calorie_goal": 2000},
+        {"effective_date": date(2026, 1, 4), "daily_calorie_goal": 2200},
+    ]
+    total, avg, ok = calculate_total_norm_for_period(
+        period_start_date=date(2026, 1, 1),
+        period_days=7,
+        historical_norms_records=history,
+        current_daily_goal=2100,
+    )
+    # days 1-3: 2000, days 4-7: 2200
+    assert ok is True
+    assert total == (3 * 2000) + (4 * 2200)
+    assert avg == round(total / 7)
+
+
+def test_calculate_total_norm_history_gap_fallback_to_current_goal():
+    history = [
+        {"effective_date": date(2026, 1, 5), "daily_calorie_goal": 2300},
+    ]
+    total, avg, ok = calculate_total_norm_for_period(
+        period_start_date=date(2026, 1, 1),
+        period_days=7,
+        historical_norms_records=history,
+        current_daily_goal=2100,
+    )
+    # days 1-4 fallback to current, days 5-7 from history
+    assert ok is True
+    assert total == (4 * 2100) + (3 * 2300)
+    assert avg == round(total / 7)
+
+
+def test_calculate_total_norm_zero_period_days():
+    total, avg, ok = calculate_total_norm_for_period(
+        period_start_date=date(2026, 1, 1),
+        period_days=0,
+        historical_norms_records=[],
+        current_daily_goal=2000,
+    )
+    assert (total, avg, ok) == (0, 0, False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,41 @@
+import pytest
+
+from utils import calculate_lbm, calculate_target_macros_and_calories
+
+
+def test_calculate_lbm_for_male_valid():
+    lbm = calculate_lbm(weight_kg=80, height_cm=180, gender="male")
+    assert lbm == pytest.approx((0.407 * 80) + (0.267 * 180) - 19.2)
+
+
+def test_calculate_lbm_for_female_valid():
+    lbm = calculate_lbm(weight_kg=65, height_cm=170, gender="female")
+    assert lbm == pytest.approx((0.252 * 65) + (0.473 * 170) - 48.3)
+
+
+def test_calculate_lbm_invalid_gender_returns_none():
+    assert calculate_lbm(weight_kg=80, height_cm=180, gender="other") is None
+
+
+def test_calculate_lbm_invalid_data_returns_none():
+    assert calculate_lbm(weight_kg=0, height_cm=180, gender="male") is None
+    assert calculate_lbm(weight_kg=80, height_cm=0, gender="male") is None
+    assert calculate_lbm(weight_kg=80, height_cm=180, gender="") is None
+
+
+def test_calculate_lbm_unrealistic_returns_none():
+    # very low weight + high height creates implausible negative result
+    assert calculate_lbm(weight_kg=30, height_cm=220, gender="male") is None
+
+
+@pytest.mark.parametrize("goal", ["deficit", "maintenance", "surplus"])
+def test_calculate_target_macros_and_calories_valid(goal):
+    _, calories = calculate_target_macros_and_calories(lbm=60.0, goal=goal)
+    assert isinstance(calories, int)
+    assert calories > 0
+
+
+def test_calculate_target_macros_and_calories_invalid_inputs():
+    assert calculate_target_macros_and_calories(lbm=0, goal="deficit") is None
+    assert calculate_target_macros_and_calories(lbm=60, goal="") is None
+    assert calculate_target_macros_and_calories(lbm=60, goal="unknown") is None


### PR DESCRIPTION
### Motivation
- Make FSM storage production-ready by preferring a Redis-backed storage while keeping a safe fallback to in-memory storage to preserve boot resilience.
- Ensure deployments using Docker Compose include a Redis service for FSM state so the runtime is self-contained on VPS/servers.
- Surface configuration for FSM storage via environment variables to allow explicit control between `redis` and `memory` modes.
- Add unit tests for the FSM storage selection path to prevent regressions.

### Description
- Added `create_fsm_storage()` in `main.py` to initialize FSM storage with Redis-first behavior (`RedisStorage.from_url`) and a safe fallback to `MemoryStorage` when Redis support or connection is unavailable, and conditionally import `RedisStorage` to avoid hard failure when the extra is not installed.
- Added `FSM_STORAGE` and `REDIS_URL` to `config.py` to allow selecting the storage type and configuring the Redis endpoint via environment variables (`FSM_STORAGE`, `REDIS_URL`).
- Updated `docker-compose.yml` to include a `redis` service (`redis:7-alpine`) with a `redis-cli` healthcheck, added `redis_data` volume, and made the `bot` service depend on both `db` and `redis` health.
- Updated `requirements.txt` to include `redis>=5.0.0`, updated `README.md` with Redis/compose instructions and `.env` examples, and added unit tests `tests/test_main_storage.py` covering Redis success, import-missing fallback, and explicit memory mode.

### Testing
- Ran `python -m compileall -q .` and bytecode compilation succeeded.
- Ran `python -m pytest -q` and all tests (including the new `tests/test_main_storage.py`) passed.
- Ran `python tests/check_critical_coverage.py` and critical-function coverage check passed (reported >95%).
- Attempted `docker compose config -q` for Compose validation but it could not run in this environment because the Docker CLI is not available (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b4ddb893083219a5e08b060e4e44c)